### PR TITLE
Browser integration

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -32,3 +32,7 @@ Template for an apache configuration:
 	  Order allow,deny
 	  Allow from all
 	</Directory>
+
+
+7. If you want to use the cvmfs-browser application uncomment and configure the options included in setting.py.example.
+        NOTE: It will be necessary to install the cvmfs-browser application. It can be found in https://github.com/cvmfs/cvmfs-browser

--- a/cvmfs_web/settings.py.example
+++ b/cvmfs_web/settings.py.example
@@ -180,11 +180,26 @@ LOGGING = {
 
 MONITOR_SHOW_BROWSER_URL = False
 
+# Number of tags that will be visualized per page
 # CLOUD_BROWSER_DEFAULT_LIST_LIMIT = 20
-# CLOUD_BROWSER_DATASTORE = "CVMFilesystem"
-# CLOUD_BROWSER_CVMFS_CACHE = os.path.join(BASE_DIR, '/tmp/cvmfs_cache')  # change this accordingly
+
+# If using the cvmfs-browser uncomment this line
+# CLOUD_BROWSER_DATASTORE = 'CVMFilesystem'
+
+# change this accordingly and DO NOT FORGET TO CREATE THE DIRECTORY BEFORE
+# please also note this cache will contain the uncompressed files that are
+# downloaded upon user request and so far it won't be deleted (unless
+# manually, of course).
+# CLOUD_BROWSER_CVMFS_CACHE = os.path.join(BASE_DIR, '/tmp/cvmfs_cache')
+
+# if you want to enable only certain repositories fill in this field.
+# For example:
+# [ 'atlas.cern.ch', 'lhcb.cern.ch', 'alice.cern.ch', 'cms.cern.ch' ]
 # CLOUD_BROWSER_CVMFS_FQRN_WHITELIST = []  # all allowed
 
+# set the mapping of FQRN -> stratum1 URL
+# For example, atlas.cern.ch would be mapped to
+# http://cvmfs-stratum-one.cern.ch/opt/atlas because it ends in '.cern.ch'
 # CLOUD_BROWSER_CVMFS_URL_MAPPING = {
 #     '.cern.ch': 'http://cvmfs-stratum-one.cern.ch/opt/',
 #     '.desy.de': 'http://cvmfs-stratum-one.cern.ch/cvmfs/',

--- a/cvmfs_web/settings.py.example
+++ b/cvmfs_web/settings.py.example
@@ -141,8 +141,8 @@ INSTALLED_APPS = (
     # 'django.contrib.admindocs',
     'stratum0',
 
-    # migration system
-    'south'
+    # necessary for the browser
+    #'cloud_browser',
 )
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
@@ -175,3 +175,20 @@ LOGGING = {
         },
     }
 }
+
+# browser-related parameters
+
+MONITOR_SHOW_BROWSER_URL = False
+
+# CLOUD_BROWSER_DEFAULT_LIST_LIMIT = 20
+# CLOUD_BROWSER_DATASTORE = "CVMFilesystem"
+# CLOUD_BROWSER_CVMFS_CACHE = os.path.join(BASE_DIR, '/tmp/cvmfs_cache')  # change this accordingly
+# CLOUD_BROWSER_CVMFS_FQRN_WHITELIST = []  # all allowed
+
+# CLOUD_BROWSER_CVMFS_URL_MAPPING = {
+#     '.cern.ch': 'http://cvmfs-stratum-one.cern.ch/opt/',
+#     '.desy.de': 'http://cvmfs-stratum-one.cern.ch/cvmfs/',
+#     '.egi.eu': 'http://cvmfs-egi.gridpp.rl.ac.uk:8000/cvmfs/',
+#     '.amc.nl': 'http://cvmfs01.nikhef.nl/cvmfs/',
+#     '.opensciencegrid.org': 'http://cvmfs.racf.bnl.gov/cvmfs/',
+# }

--- a/cvmfs_web/settings.py.example
+++ b/cvmfs_web/settings.py.example
@@ -142,7 +142,7 @@ INSTALLED_APPS = (
     'stratum0',
 
     # necessary for the browser
-    #'cloud_browser',
+    #'cvmfs_browser',
 )
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'

--- a/cvmfs_web/settings.py.example
+++ b/cvmfs_web/settings.py.example
@@ -176,7 +176,10 @@ LOGGING = {
     }
 }
 
+############################
 # browser-related parameters
+############################
+
 
 MONITOR_SHOW_BROWSER_URL = False
 
@@ -186,8 +189,8 @@ MONITOR_SHOW_BROWSER_URL = False
 # If using the cvmfs-browser uncomment this line
 # CLOUD_BROWSER_DATASTORE = 'CVMFilesystem'
 
-# change this accordingly and DO NOT FORGET TO CREATE THE DIRECTORY BEFORE
-# please also note this cache will contain the uncompressed files that are
+# change this accordingly and DO NOT FORGET TO CREATE THE DIRECTORY BEFORE.
+# Please also note this cache will contain the uncompressed files that are
 # downloaded upon user request and so far it won't be deleted (unless
 # manually, of course).
 # CLOUD_BROWSER_CVMFS_CACHE = os.path.join(BASE_DIR, '/tmp/cvmfs_cache')

--- a/cvmfs_web/settings.py.example
+++ b/cvmfs_web/settings.py.example
@@ -195,11 +195,6 @@ MONITOR_SHOW_BROWSER_URL = False
 # manually, of course).
 # CLOUD_BROWSER_CVMFS_CACHE = os.path.join(BASE_DIR, '/tmp/cvmfs_cache')
 
-# if you want to enable only certain repositories fill in this field.
-# For example:
-# [ 'atlas.cern.ch', 'lhcb.cern.ch', 'alice.cern.ch', 'cms.cern.ch' ]
-# CLOUD_BROWSER_CVMFS_FQRN_WHITELIST = []  # all allowed
-
 # set the mapping of FQRN -> stratum1 URL
 # For example, atlas.cern.ch would be mapped to
 # http://cvmfs-stratum-one.cern.ch/opt/atlas because it ends in '.cern.ch'

--- a/cvmfs_web/settings.py.example
+++ b/cvmfs_web/settings.py.example
@@ -186,14 +186,11 @@ MONITOR_SHOW_BROWSER_URL = False
 # Number of tags that will be visualized per page
 # CLOUD_BROWSER_DEFAULT_LIST_LIMIT = 20
 
-# If using the cvmfs-browser uncomment this line
-# CLOUD_BROWSER_DATASTORE = 'CVMFilesystem'
-
 # change this accordingly and DO NOT FORGET TO CREATE THE DIRECTORY BEFORE.
 # Please also note this cache will contain the uncompressed files that are
 # downloaded upon user request and so far it won't be deleted (unless
 # manually, of course).
-# CLOUD_BROWSER_CVMFS_CACHE = os.path.join(BASE_DIR, '/tmp/cvmfs_cache')
+# CLOUD_BROWSER_CVMFS_CACHE = os.path.join(BASE_DIR, 'cvmfs_cache')
 
 # set the mapping of FQRN -> stratum1 URL
 # For example, atlas.cern.ch would be mapped to

--- a/cvmfs_web/urls.py
+++ b/cvmfs_web/urls.py
@@ -9,5 +9,5 @@ urlpatterns = patterns('',
     url(r'^$', include('stratum0.urls')),
 
     # option for the browser
-    # url(r'^cb/', include('cloud_browser.urls')),
+    # url(r'^cb/', include('cvmfs_browser.urls')),
 )

--- a/cvmfs_web/urls.py
+++ b/cvmfs_web/urls.py
@@ -6,8 +6,8 @@ admin.autodiscover()
 
 urlpatterns = patterns('',
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^$', include('stratum0.urls')),
 
     # option for the browser
     # url(r'^cb/', include('cvmfs_browser.urls')),
+    url(r'^', include('stratum0.urls')),
 )

--- a/cvmfs_web/urls.py
+++ b/cvmfs_web/urls.py
@@ -6,5 +6,8 @@ admin.autodiscover()
 
 urlpatterns = patterns('',
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^', include('stratum0.urls')),
+    url(r'^$', include('stratum0.urls')),
+
+    # option for the browser
+    # url(r'^cb/', include('cloud_browser.urls')),
 )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
     'Topic :: System :: Systems Administration'
   ],
   packages=find_packages(),
+  include_package_data=True,
+  zip_safe=False,
   install_requires=[ # don't forget to adapt the matching RPM dependencies!
     'python-cvmfsutils >= 0.1.0',
     'Django >= 1.8',

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     'python-cvmfsutils >= 0.1.0',
     'Django >= 1.8',
     # if using the cvmfs-browser
-    # 'cloud_browser'
+    # 'cvmfs_browser >= 0.2.0'
   ]
 )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,5 @@ setup(
   install_requires=[ # don't forget to adapt the matching RPM dependencies!
     'python-cvmfsutils >= 0.1.0',
     'Django >= 1.4',
-    'South >= 0.7.5'
   ]
 )

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,7 @@ setup(
   install_requires=[ # don't forget to adapt the matching RPM dependencies!
     'python-cvmfsutils >= 0.1.0',
     'Django >= 1.4',
+    # if using the cvmfs-browser
+    # 'cloud_browser'
   ]
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
   packages=find_packages(),
   install_requires=[ # don't forget to adapt the matching RPM dependencies!
     'python-cvmfsutils >= 0.1.0',
-    'Django >= 1.4',
+    'Django >= 1.8',
     # if using the cvmfs-browser
     # 'cloud_browser'
   ]

--- a/stratum0/templates/stratum0/details.html
+++ b/stratum0/templates/stratum0/details.html
@@ -162,6 +162,12 @@ window.onload = function() {
             <td>Description:</td>
             <td class="project_description">{{ stratum0.project_description }}</td>
         </tr>
+        {% if display_browser_url %}
+        <tr>
+            <td>Browse:</td>
+            <td class="project_description"><a href="/cb/browser/{{ stratum0.fqrn }}/latest">{{ stratum0.fqrn }}</a></td>
+        </tr>
+        {% endif %}
     </table>
 </div>
 

--- a/stratum0/views.py
+++ b/stratum0/views.py
@@ -1,10 +1,6 @@
 from django.shortcuts import render, get_object_or_404
-from django.http import Http404, HttpResponse
-from django.views.generic.base import RedirectView
 from django.views.decorators.cache import never_cache, cache_page
-from django.core.urlresolvers import reverse_lazy
-from datetime import datetime
-from dateutil.tz import tzutc
+from django.conf import settings
 
 from stratum0.models import Stratum0, Stratum1, ReplicationSite
 
@@ -19,7 +15,8 @@ def details(request, stratum0_fqrn):
     stratum0  = get_object_or_404(Stratum0, fqrn=stratum0_fqrn)
     stratum1s = Stratum1.objects.filter(stratum0=stratum0)
     context   = { 'stratum0'  : stratum0,
-                  'stratum1s' : stratum1s }
+                  'stratum1s' : stratum1s,
+                  'display_browser_url': settings.MONITOR_SHOW_BROWSER_URL }
     return render(request, 'stratum0/details.html', context)
 
 


### PR DESCRIPTION
This PR does the strictly necessary things to integrate the cvmfs-browser in an optional way, modifying settings.py.example accordingly. It also removes the dependency of South for Django 1.4 and updates that dependency to 1.8 since South is now integrated in Django.

Also it's noticeable that this dependency with the browser is absolutely optional, and actually disabled by default.

From the user perspective it would display the url in the basic description of the repository if enabled.